### PR TITLE
(PE-16465) Add windows and windowsfips to platform_repos

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -112,6 +112,10 @@ platform_repos:
     repo_location: repos/solaris/11/**/*.i386.p5p
   - name: solaris-11-sparc
     repo_location: repos/solaris/11/**/*.sparc.p5p
+  - name: windows
+    repo_location: repos/windows
+  - name: windowsfips
+    repo_location: repos/windowsfips
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '7F438280EF8D349F'
 deb_targets: 'xenial-amd64 bionic-amd64'


### PR DESCRIPTION
This adds the windows and windowsfips repos to the
puppet-agent-all.tar.gz tarball.